### PR TITLE
Can't get exceptions handled in the filter chain

### DIFF
--- a/filters/src/main/scala/org/example/clumpzootsample/Filters.scala
+++ b/filters/src/main/scala/org/example/clumpzootsample/Filters.scala
@@ -3,12 +3,25 @@ package org.example.clumpzootsample
 import net.fwbrasil.zoot.core.filter.Filter
 import net.fwbrasil.zoot.core.request.Request
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object Filters {
   val requestLogFilter =
     new Filter {
       override def apply(request: Request, next: Service) = {
         println(s"request $request")
         next(request)
+      }
+    }
+
+  val exceptionLogFilter =
+    new Filter {
+      override def apply(request: Request, next: Service) = {
+        val response = next(request)
+        response.onFailure {
+          case _ => println(s"Exception was thrown!")
+        }
+        response
       }
     }
 }

--- a/presentation/src/main/scala/org/example/clumpzootsample/PresentationService.scala
+++ b/presentation/src/main/scala/org/example/clumpzootsample/PresentationService.scala
@@ -3,7 +3,7 @@ package org.example.clumpzootsample
 import com.twitter.util.Future
 import io.getclump.{ClumpSource, Clump}
 import net.fwbrasil.zoot.finagle.FutureBridge._
-import org.example.clumpzootsample.Filters.requestLogFilter
+import org.example.clumpzootsample.Filters.{exceptionLogFilter, requestLogFilter}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -12,7 +12,8 @@ object PresentationService extends App {
   val usersService = Create.clientFor[Users]("localhost", 2222)
   val tracks = Clump.source(tracksService.list)(_.id)
   val users = Clump.source(usersService.list)(_.id)
-  Create.serverFor[EnrichedTracks]("EnrichedTracks", 1111, new EnrichedTracksController(tracks, users), requestLogFilter)
+  Create.serverFor[EnrichedTracks]("EnrichedTracks", 1111, new EnrichedTracksController(tracks, users),
+    requestLogFilter, exceptionLogFilter)
 }
 
 class EnrichedTracksController(tracks: ClumpSource[Long, Track], users: ClumpSource[Long, User]) extends EnrichedTracks {
@@ -27,6 +28,7 @@ class EnrichedTracksController(tracks: ClumpSource[Long, Track], users: ClumpSou
     track <- tracks.get(trackId)
     user <- users.get(track.creatorId)
   } yield {
+    throw new RuntimeException("Expected")
     EnrichedTrack(track.title, s"${user.firstName} ${user.lastName}")
   }
 }


### PR DESCRIPTION
It looks like Zoot is swallowing exceptions before they arrive at the filter chain
